### PR TITLE
feat: support options.include/exclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "test": "jest"
     },
     "dependencies": {
+        "@rollup/pluginutils": "^4.2.1",
         "vue-docgen-api": "^4.40.0"
     },
     "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,37 +2,44 @@ import {
     parse,
     DocGenOptions
 } from 'vue-docgen-api';
+import { createFilter, FilterPattern } from '@rollup/pluginutils';
 
 import type {
     Plugin
 } from 'vite';
 
 export interface Options {
+    /** @deprecated please use `include` instead */
     pattern?: RegExp;
+    include?: FilterPattern;
+    exclude?: FilterPattern;
     injectAt?: string;
     docgenOptions?: DocGenOptions;
 }
 
 export default function(options?: Options): Plugin {
     const {
-        pattern,
         injectAt,
+        include,
+        exclude,
         docgenOptions
     } = {
-        pattern: /\.vue$/,
+        include: options?.include || options?.pattern || /\.vue$/,
         injectAt: '__docgenInfo',
         ...options
     };
+
+    var filter = createFilter(include, exclude);
 
     return {
         name: 'vite-plugin-vue-docgen',
         enforce: 'post',
 
         async transform(source, id, ssr) {
-            if (!pattern.test(id)) {
+            if (!filter(id)) {
                 return;
             }
-
+            
             const metaData = await parse(id, docgenOptions);
             const metaSource = JSON.stringify(metaData);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,6 +519,14 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@rollup/pluginutils@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -2583,6 +2591,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+picomatch@^2.2.2:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pirates@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
They are more standard in the rollup/vite plugin ecosystem
My usecase is excluding things, and unfortunately having a
single pattern does not cut it because I am in a browser environment
and Safari does not support negative lookahead in regexps
